### PR TITLE
Manuel/added datetimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 articles.json
+.env

--- a/delays.js
+++ b/delays.js
@@ -1,0 +1,39 @@
+const spinnerChars = ["|", "/", "-", "\\"];
+let spinnerIndex = 0;
+let spinnerInterval;
+
+// Starts a loading animation in terminal.
+const startSpinner = () => {
+  if (!spinnerInterval) {
+    spinnerInterval = setInterval(() => {
+      process.stdout.clearLine(0);
+      process.stdout.cursorTo(0);
+      process.stdout.write(spinnerChars[spinnerIndex]);
+      spinnerIndex = (spinnerIndex + 1) % spinnerChars.length;
+    }, 250);
+  }
+};
+
+// Stops loading animation in terminal.
+const stopSpinner = () => {
+  clearInterval(spinnerInterval);
+  spinnerInterval = null;
+  process.stdout.clearLine(0);
+  process.stdout.cursorTo(0);
+};
+
+// Makes fetch request with a small delay of 1 to 3 seconds.
+const smallFetchDelay = async (url) => {
+  const delay = Math.floor(Math.random() * 3) + 1;
+  await new Promise((resolve) => setTimeout(resolve, delay * 1000));
+  return fetch(url).then((response) => response.text());
+};
+
+// Makes fetch request with delay of 1 to 6 seconds.
+const fetchDelay = async (url) => {
+  const delay = Math.floor(Math.random() * 6) + 1;
+  await new Promise((resolve) => setTimeout(resolve, delay * 1000));
+  return fetch(url).then((response) => response.text());
+};
+
+module.exports = { startSpinner, stopSpinner, smallFetchDelay, fetchDelay };

--- a/delays.js
+++ b/delays.js
@@ -36,4 +36,21 @@ const fetchDelay = async (url) => {
   return fetch(url).then((response) => response.text());
 };
 
-module.exports = { startSpinner, stopSpinner, smallFetchDelay, fetchDelay };
+const fetchDelayTracy = async (url) => {
+  const delay = Math.floor(Math.random() * 6) + 1;
+  await new Promise((resolve) => setTimeout(resolve, delay * 1000));
+  return fetch(url, { signal: AbortSignal.timeout(10000) }).then((response) => {
+    if (typeof response == "string") {
+      return response;
+    }
+    return response.text();
+  });
+};
+
+module.exports = {
+  startSpinner,
+  stopSpinner,
+  smallFetchDelay,
+  fetchDelay,
+  fetchDelayTracy,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,21 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.7",
-        "cheerio": "^1.0.0-rc.12"
+        "cheerio": "^1.0.0-rc.12",
+        "dotenv": "^16.4.5",
+        "https-proxy-agent": "^7.0.4",
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/asynckit": {
@@ -106,6 +120,22 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -165,6 +195,17 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -177,9 +218,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -226,6 +267,18 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -243,6 +296,30 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/nth-check": {
@@ -283,6 +360,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cheerio": "^1.0.0-rc.12",
         "dotenv": "^16.4.5",
         "https-proxy-agent": "^7.0.4",
+        "moment": "^2.30.1",
         "node-fetch": "^2.7.0"
       }
     },
@@ -296,6 +297,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.6.7",
-    "cheerio": "^1.0.0-rc.12"
+    "cheerio": "^1.0.0-rc.12",
+    "dotenv": "^16.4.5",
+    "https-proxy-agent": "^7.0.4",
+    "node-fetch": "^2.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cheerio": "^1.0.0-rc.12",
     "dotenv": "^16.4.5",
     "https-proxy-agent": "^7.0.4",
+    "moment": "^2.30.1",
     "node-fetch": "^2.7.0"
   }
 }

--- a/proxyFetch.js
+++ b/proxyFetch.js
@@ -1,6 +1,8 @@
 require("dotenv").config();
 const { HttpsProxyAgent } = require("https-proxy-agent");
 
+const { smallFetchDelay, fetchDelay } = require("./delays");
+
 // Array of proxy objects
 const proxies = [
   { ip: process.env.PROXY_IP_1, port: process.env.PORT_1 },
@@ -93,6 +95,8 @@ function getRandomIndex() {
 // Function to make fetch request using random proxy.
 async function fetchWithProxy(url) {
   try {
+    const delay = Math.floor(Math.random() * 10) + 1;
+    await new Promise((resolve) => setTimeout(resolve, delay * 1000));
     const index = getRandomIndex();
 
     const ip = proxies[index].ip;
@@ -106,6 +110,7 @@ async function fetchWithProxy(url) {
       agent: proxyAgent,
       method: "GET",
       cache: "no-cache",
+      signal: AbortSignal.timeout(15000),
     });
     return await response.text();
   } catch (e) {

--- a/proxyFetch.js
+++ b/proxyFetch.js
@@ -1,0 +1,116 @@
+require("dotenv").config();
+const { HttpsProxyAgent } = require("https-proxy-agent");
+
+// Array of proxy objects
+const proxies = [
+  { ip: process.env.PROXY_IP_1, port: process.env.PORT_1 },
+  { ip: process.env.PROXY_IP_2, port: process.env.PORT_2 },
+  { ip: process.env.PROXY_IP_3, port: process.env.PORT_3 },
+  { ip: process.env.PROXY_IP_4, port: process.env.PORT_4 },
+  { ip: process.env.PROXY_IP_5, port: process.env.PORT_5 },
+  { ip: process.env.PROXY_IP_6, port: process.env.PORT_6 },
+  { ip: process.env.PROXY_IP_7, port: process.env.PORT_7 },
+  { ip: process.env.PROXY_IP_8, port: process.env.PORT_8 },
+  { ip: process.env.PROXY_IP_9, port: process.env.PORT_9 },
+  { ip: process.env.PROXY_IP_10, port: process.env.PORT_10 },
+];
+
+const headers = [
+  {
+    "User-Agent":
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36",
+    Accept:
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "Accept-Language": "en-US,en;q=0.9",
+  },
+  {
+    "User-Agent":
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0",
+    Accept:
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+  },
+  {
+    "User-Agent":
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15",
+    Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-us",
+  },
+  {
+    "User-Agent":
+      "Mozilla/5.0 (Linux; Android 10; SM-G981B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.210 Mobile Safari/537.36",
+    Accept:
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "Accept-Language": "en-US,en;q=0.9",
+  },
+  {
+    "User-Agent":
+      "Mozilla/5.0 (Android 10; Mobile; rv:88.0) Gecko/88.0 Firefox/88.0",
+    Accept:
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+  },
+  {
+    "User-Agent":
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.818.62 Safari/537.36 Edg/90.0.818.46",
+    Accept:
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "Accept-Language": "en-US,en;q=0.9",
+  },
+  {
+    "User-Agent":
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1",
+    Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+  },
+  {
+    "User-Agent":
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1",
+    Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+  },
+  {
+    "User-Agent":
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36 OPR/60.0.3255.170",
+    Accept:
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "Accept-Language": "en-US,en;q=0.9",
+  },
+  {
+    "User-Agent":
+      "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko",
+    Accept: "text/html, application/xhtml+xml, image/jxr, */*",
+    "Accept-Language": "en-US,en;q=0.5",
+  },
+];
+
+// Function to pick a random proxy object from list.
+function getRandomIndex() {
+  const randIndex = Math.floor(Math.random() * proxies.length);
+  return randIndex;
+}
+
+// Function to make fetch request using random proxy.
+async function fetchWithProxy(url) {
+  try {
+    const index = getRandomIndex();
+
+    const ip = proxies[index].ip;
+    const port = proxies[index].port;
+    const header = headers[index];
+
+    const proxyAgent = new HttpsProxyAgent(`https://${ip}:${port}`);
+
+    const response = await fetch(url, {
+      headers: header,
+      agent: proxyAgent,
+      method: "GET",
+      cache: "no-cache",
+    });
+    return await response.text();
+  } catch (e) {
+    console.error("Proxy Request  Failed:", e);
+  }
+}
+
+module.exports = { fetchWithProxy };

--- a/proxyFetch.js
+++ b/proxyFetch.js
@@ -118,4 +118,33 @@ async function fetchWithProxy(url) {
   }
 }
 
-module.exports = { fetchWithProxy };
+// Function to make fetch request using random proxy.
+async function fetchWithProxyTracy(url) {
+  try {
+    const delay = Math.floor(Math.random() * 10) + 1;
+    await new Promise((resolve) => setTimeout(resolve, delay * 1000));
+    const index = getRandomIndex();
+
+    const ip = proxies[index].ip;
+    const port = proxies[index].port;
+    const header = headers[index];
+
+    const proxyAgent = new HttpsProxyAgent(`https://${ip}:${port}`);
+
+    const response = await fetch(url, {
+      headers: header,
+      agent: proxyAgent,
+      method: "GET",
+      cache: "no-cache",
+      signal: AbortSignal.timeout(15000),
+    });
+    if (typeof response == "string") {
+      return response;
+    }
+    return response.text();
+  } catch (e) {
+    console.error("Proxy Request  Failed:", e);
+  }
+}
+
+module.exports = { fetchWithProxy, fetchWithProxyTracy };

--- a/scrapeData.js
+++ b/scrapeData.js
@@ -161,6 +161,6 @@ async function scrapeData(city = "all", proxy = false) {
 }
 
 // Updates Scraped Data object and will write to JSON file.
-scrapeData("modesto");
+scrapeData("oakdale");
 
 module.exports = { scrapeData };

--- a/scrapeData.js
+++ b/scrapeData.js
@@ -161,6 +161,6 @@ async function scrapeData(city = "all", proxy = false) {
 }
 
 // Updates Scraped Data object and will write to JSON file.
-scrapeData("tracy");
+scrapeData();
 
 module.exports = { scrapeData };

--- a/scrapeData.js
+++ b/scrapeData.js
@@ -161,6 +161,6 @@ async function scrapeData(city = "all", proxy = false) {
 }
 
 // Updates Scraped Data object and will write to JSON file.
-scrapeData();
+scrapeData("tracy");
 
 module.exports = { scrapeData };

--- a/scrapeData.js
+++ b/scrapeData.js
@@ -134,7 +134,7 @@ async function scrapeData(city = "all", proxy = false) {
           `Scraped ${riverbankArr.length} articles from The Riverbank News\n`
         );
       } catch (e) {
-        console.log(`Failed to scrape Oakdale. Error ${e.message}\n`);
+        console.log(`Failed to scrape Riverbank. Error ${e.message}\n`);
       }
       try {
         proxy
@@ -145,7 +145,7 @@ async function scrapeData(city = "all", proxy = false) {
           `Scraped ${riponArr.length} articles from The Ripon Press\n`
         );
       } catch (e) {
-        console.log(`Failed to scrape Oakdale. Error ${e.message}\n`);
+        console.log(`Failed to scrape Ripon. Error ${e.message}\n`);
       }
 
       console.log(`Scraped a Total of ${articles.length} Articles. \n`);

--- a/scrapeData.js
+++ b/scrapeData.js
@@ -161,6 +161,6 @@ async function scrapeData(city = "all", proxy = false) {
 }
 
 // Updates Scraped Data object and will write to JSON file.
-scrapeData("oakdale");
+scrapeData();
 
 module.exports = { scrapeData };

--- a/scrapeData.js
+++ b/scrapeData.js
@@ -161,6 +161,6 @@ async function scrapeData(city = "all", proxy = false) {
 }
 
 // Updates Scraped Data object and will write to JSON file.
-scrapeData();
+scrapeData("modesto");
 
 module.exports = { scrapeData };

--- a/scrapeData.js
+++ b/scrapeData.js
@@ -13,13 +13,15 @@ const { riponScraper } = require("./scrapers/riponScraper");
 //// FUNCTIONS ////
 // @ desc Scrapes city data or all cities if all is passed as arg.
 // @ returns an array of objects where each object represents an article with the data we need as properties.
-async function scrapeData(city = "all") {
+async function scrapeData(city = "all", proxy = false) {
   console.log("\n");
   let articles = [];
   console.time();
   switch (city) {
     case "turlock":
-      articles = await turlockJournalScraper();
+      proxy
+        ? (articles = await turlockJournalScraper(true))
+        : (articles = await turlockJournalScraper());
       console.log(
         `Scraped ${articles.length} articles from The Turlock Journal`
       );
@@ -29,7 +31,9 @@ async function scrapeData(city = "all") {
       );
       break;
     case "modesto":
-      articles = await modestoBeeScraper();
+      proxy
+        ? (articles = await modestoBeeScraper(true))
+        : (articles = await modestoBeeScraper());
       console.log(`Scraped ${articles.length} articles from The Modesto Bee`);
       await writeFile(
         path.join(process.cwd(), "articles.json"),
@@ -37,7 +41,9 @@ async function scrapeData(city = "all") {
       );
       break;
     case "oakdale":
-      articles = await oakdaleLeaderScraper();
+      proxy
+        ? (articles = await oakdaleLeaderScraper(true))
+        : (articles = await oakdaleLeaderScraper());
       console.log(
         `Scraped ${articles.length} articles from The Oakdale Leader`
       );
@@ -47,7 +53,9 @@ async function scrapeData(city = "all") {
       );
       break;
     case "riverbank":
-      articles = await riverbankNewsScraper();
+      proxy
+        ? (articles = await riverbankNewsScraper(true))
+        : (articles = await riverbankNewsScraper());
       console.log(`Scraped ${articles.length} articles from Riverbank News`);
       await writeFile(
         path.join(process.cwd(), "articles.json"),
@@ -55,7 +63,9 @@ async function scrapeData(city = "all") {
       );
       break;
     case "tracy":
-      articles = await tracyPressScraper();
+      proxy
+        ? (articles = await tracyPressScraper(true))
+        : (articles = await tracyPressScraper());
       console.log(`Scraped ${articles.length} articles from Tracy Press`);
       await writeFile(
         path.join(process.cwd(), "articles.json"),
@@ -63,7 +73,9 @@ async function scrapeData(city = "all") {
       );
       break;
     case "ripon":
-      articles = await riponScraper();
+      proxy
+        ? (articles = await riponScraper(true))
+        : (articles = await riponScraper());
       console.log(`Scraped ${articles.length} articles from Ripon Press`);
       await writeFile(
         path.join(process.cwd(), "articles.json"),
@@ -72,25 +84,9 @@ async function scrapeData(city = "all") {
       break;
     case "all":
       try {
-        tracyArr = await tracyPressScraper();
-        articles = [...articles, ...tracyArr];
-        console.log(
-          `Scraped ${tracyArr.length} articles from The Tracy Press\n`
-        );
-      } catch (e) {
-        console.log(`Failed to scrape Tracy. Error ${e.message}\n`);
-      }
-      try {
-        turlockArr = await turlockJournalScraper();
-        articles = [...articles, ...turlockArr];
-        console.log(
-          `Scraped ${turlockArr.length} articles from The Turlock Journal\n`
-        );
-      } catch (e) {
-        console.log(`Failed to scrape Turlock. Error ${e.message}\n`);
-      }
-      try {
-        modestoArr = await modestoBeeScraper();
+        proxy
+          ? (modestoArr = await modestoBeeScraper(true))
+          : (modestoArr = await modestoBeeScraper());
         articles = [...articles, ...modestoArr];
         console.log(
           `Scraped ${modestoArr.length} articles from The Modesto Bee\n`
@@ -99,14 +95,40 @@ async function scrapeData(city = "all") {
         console.log(`Failed to scrape Modesto. Error: ${e.message}\n`);
       }
       try {
-        oakdaleArr = await oakdaleLeaderScraper();
+        proxy
+          ? (tracyArr = await tracyPressScraper(true))
+          : (tracyArr = await tracyPressScraper());
+        articles = [...articles, ...tracyArr];
+        console.log(
+          `Scraped ${tracyArr.length} articles from The Tracy Press\n`
+        );
+      } catch (e) {
+        console.log(`Failed to scrape Tracy. Error ${e.message}\n`);
+      }
+      try {
+        proxy
+          ? (turlockArr = await turlockJournalScraper(true))
+          : (turlockArr = await turlockJournalScraper());
+        articles = [...articles, ...turlockArr];
+        console.log(
+          `Scraped ${turlockArr.length} articles from The Turlock Journal\n`
+        );
+      } catch (e) {
+        console.log(`Failed to scrape Turlock. Error ${e.message}\n`);
+      }
+      try {
+        proxy
+          ? (oakdaleArr = await oakdaleLeaderScraper(true))
+          : (oakdaleArr = await oakdaleLeaderScraper());
         articles = [...articles, ...oakdaleArr];
         console.log(`Scraped ${oakdaleArr.length} from The Oakdale Leader\n`);
       } catch (e) {
         console.log(`Failed to scrape Oakdale. Error ${e.message}\n`);
       }
       try {
-        riverbankArr = await riverbankNewsScraper();
+        proxy
+          ? (riverbankArr = await riverbankNewsScraper(true))
+          : (riverbankArr = await riverbankNewsScraper());
         articles = [...articles, ...riverbankArr];
         console.log(
           `Scraped ${riverbankArr.length} articles from The Riverbank News\n`
@@ -115,7 +137,9 @@ async function scrapeData(city = "all") {
         console.log(`Failed to scrape Oakdale. Error ${e.message}\n`);
       }
       try {
-        riponArr = await riponScraper();
+        proxy
+          ? (riponArr = await riponScraper(true))
+          : (riponArr = await riponScraper());
         articles = [...articles, ...riponArr];
         console.log(
           `Scraped ${riponArr.length} articles from The Ripon Press\n`
@@ -137,6 +161,6 @@ async function scrapeData(city = "all") {
 }
 
 // Updates Scraped Data object and will write to JSON file.
-scrapeData("ripon");
+scrapeData();
 
 module.exports = { scrapeData };

--- a/scrapers/modestoScraper.js
+++ b/scrapers/modestoScraper.js
@@ -131,9 +131,6 @@ const modestoBeeScraper = async (proxy = false) => {
 
   // Iterating over each article DOM, creating article object, and pushing it to articles array.
   for (let i = 0; i < articleDOMS.length; i++) {
-    if ((articleDOMS[i] = undefined)) {
-      continue;
-    }
     const articleObject = {};
 
     // Creating a main cheerio object out of current url.
@@ -149,7 +146,7 @@ const modestoBeeScraper = async (proxy = false) => {
       $("time.update-date").text() || $("time.publish-date").text() || null;
     let datetime;
     try {
-      datetime = moment($("time.datetime").text()).toDate();
+      datetime = moment($("time").attr("datetime")).toDate();
     } catch {
       datetime = null;
     }

--- a/scrapers/modestoScraper.js
+++ b/scrapers/modestoScraper.js
@@ -188,6 +188,7 @@ const modestoBeeScraper = async (proxy = false) => {
     articleObject["thumbnail"] = thumbnail;
     articleObject["paragraphs"] = paragraphs;
 
+    console.log(articleObject);
     // Edge case: Some modesto articles had no title and were still being worked on.
     if (articleObject.heading) {
       articles.push(articleObject);

--- a/scrapers/modestoScraper.js
+++ b/scrapers/modestoScraper.js
@@ -1,5 +1,6 @@
 const cheerio = require("cheerio");
 const { fetchWithProxy } = require("../proxyFetch");
+const moment = require("moment");
 
 // Global variable for categorizing articles.
 subcategoriesObj = {};
@@ -146,6 +147,12 @@ const modestoBeeScraper = async (proxy = false) => {
     // Getting date.
     const date =
       $("time.update-date").text() || $("time.publish-date").text() || null;
+    let datetime;
+    try {
+      datetime = moment($("time.datetime").text()).toDate();
+    } catch {
+      datetime = null;
+    }
     const thumbnail = thumbnails[i];
 
     // Getting Image.
@@ -179,6 +186,7 @@ const modestoBeeScraper = async (proxy = false) => {
     articleObject["subcategory"] = subcategory;
     articleObject["author"] = author;
     articleObject["date"] = date;
+    articleObject["datetime"] = datetime;
     articleObject["image"] = image;
     articleObject["thumbnail"] = thumbnail;
     articleObject["paragraphs"] = paragraphs;

--- a/scrapers/oakdaleScraper.js
+++ b/scrapers/oakdaleScraper.js
@@ -1,5 +1,6 @@
 const cheerio = require("cheerio");
 const { fetchWithProxy } = require("../proxyFetch");
+const moment = require("moment");
 
 // Global Variable //
 const subcategoriesObj = {};
@@ -165,6 +166,7 @@ const oakdaleLeaderScraper = async (proxy = false) => {
     const subHeading = $("div.anvil-article__subtitle").text().trim() || null;
     const author = jsonData.page_meta.author || paragraphs[0];
     const date = jsonData.page_meta.page_created_at_pretty;
+    const datetime = moment(date, "MMMM D, YYYY").toDate();
     const image = { src: $image.attr("src"), alt: $image.attr("alt") };
 
     // Saving data to an object I will push to the array of objects.
@@ -176,6 +178,7 @@ const oakdaleLeaderScraper = async (proxy = false) => {
     objectToPush["subcategory"] = subcategory;
     objectToPush["author"] = author;
     objectToPush["date"] = date;
+    objectToPush["datetime"] = datetime;
     objectToPush["img"] = image;
     objectToPush["thumbnail"] = thumbnails[i];
     objectToPush["paragraphs"] = paragraphs;

--- a/scrapers/oakdaleScraper.js
+++ b/scrapers/oakdaleScraper.js
@@ -36,7 +36,7 @@ const getOakdaleURLS = async (proxy = false) => {
   let localNewsPromise;
   let localSportsPromise;
   // Getting Category DOMS
-  process.stdout.write("Fetching Category DOMS ");
+  console.log("Fetching Category DOMS ");
   startSpinner();
   crimePromise = fetch(crimeURL).then((res) => res.text());
   govPromise = fetch(govURL).then((res) => res.text());
@@ -102,7 +102,7 @@ const oakdaleLeaderScraper = async (proxy = false) => {
 
   // Getting article DOMS
   let URLpromises;
-  console.log("Fetching article DOMS ");
+  console.log("Getting article DOMS ");
   startSpinner();
   URLpromises = urls.map((url) => {
     return fetch(url).then((res) => res.text());

--- a/scrapers/oakdaleScraper.js
+++ b/scrapers/oakdaleScraper.js
@@ -166,7 +166,7 @@ const oakdaleLeaderScraper = async (proxy = false) => {
     const subHeading = $("div.anvil-article__subtitle").text().trim() || null;
     const author = jsonData.page_meta.author || paragraphs[0];
     const date = jsonData.page_meta.page_created_at_pretty;
-    const datetime = moment(date, "MMMM D, YYYY").toDate();
+    const datetime = moment(jsonData.page_created_at).toDate();
     const image = { src: $image.attr("src"), alt: $image.attr("alt") };
 
     // Saving data to an object I will push to the array of objects.

--- a/scrapers/riponScraper.js
+++ b/scrapers/riponScraper.js
@@ -79,7 +79,7 @@ const riponScraper = async (proxy = false) => {
 
   // Getting article DOMS
   let URLpromises;
-  console.log("Fetching article DOMS ");
+  console.log("Getting article DOMS ");
   startSpinner();
   URLpromises = urls.map((url) => {
     return fetch(url).then((res) => res.text());

--- a/scrapers/riponScraper.js
+++ b/scrapers/riponScraper.js
@@ -2,6 +2,7 @@
 const cheerio = require("cheerio");
 const { fetchWithProxy } = require("../proxyFetch");
 const moment = require("moment");
+const { startSpinner, stopSpinner } = require("../delays");
 
 // @ desc Scrapes Ripon Leader for article URLS.
 // @ returns array of article URLS to scrape.
@@ -26,22 +27,18 @@ const getRiponURLS = async (proxy = false) => {
   let localNewsPromise;
   let highSchoolPromise;
   // Getting Category DOM.
-  if (!proxy) {
-    console.log("Fetching Category DOMS");
-    edPromise = fetch(edURL).then((res) => res.text());
-    localNewsPromise = fetch(localNewsURL).then((res) => res.text());
-    highSchoolPromise = fetch(highSchoolURL).then((res) => res.text());
-  } else {
-    console.log("Fetching Category DOMS with Proxy");
-    edPromise = fetchWithProxy(edURL);
-    localNewsPromise = fetchWithProxy(localNewsURL);
-    highSchoolPromise = fetchWithProxy(highSchoolURL);
-  }
+
+  console.log("Fetching Category DOMS ");
+  startSpinner();
+  edPromise = fetch(edURL).then((res) => res.text());
+  localNewsPromise = fetch(localNewsURL).then((res) => res.text());
+  highSchoolPromise = fetch(highSchoolURL).then((res) => res.text());
   const [edDOM, localNewsDOM, highSchoolDOM] = await Promise.all([
     edPromise,
     localNewsPromise,
     highSchoolPromise,
   ]);
+  stopSpinner();
   console.log("Got all Category DOMS");
 
   // Creating cheerio objects.
@@ -75,32 +72,22 @@ const riponScraper = async (proxy = false) => {
   // Getting article URLS
   let urls;
   let thumbnails;
-  if (!proxy) {
-    const [resURLS, resThumbnails] = await getRiponURLS();
-    urls = resURLS;
-    thumbnails = resThumbnails;
-  } else {
-    const [resURLS, resThumbnails] = await getRiponURLS(true);
-    urls = resURLS;
-    thumbnails = resThumbnails;
-  }
+  const [resURLS, resThumbnails] = await getRiponURLS();
+  urls = resURLS;
+  thumbnails = resThumbnails;
   console.log("Got all article URLS");
 
   // Getting article DOMS
   let URLpromises;
-  if (!proxy) {
-    console.log("Fetching article DOMS");
-    URLpromises = urls.map((url) => {
-      return fetch(url).then((res) => res.text());
-    });
-  } else {
-    console.log("Fetching article DOMS with Proxy");
-    URLpromises = urls.map((url) => {
-      return fetchWithProxy(url);
-    });
-  }
+  console.log("Fetching article DOMS ");
+  startSpinner();
+  URLpromises = urls.map((url) => {
+    return fetch(url).then((res) => res.text());
+  });
   const articleDOMS = await Promise.all(URLpromises);
-  console.log("Got all Article DOMS, Scraping Data...");
+  stopSpinner();
+  console.log("Got all Article DOMS, Scraping Data... ");
+  startSpinner();
 
   // Iterating over each Ripon article DOM to scrape data.
   for (let i = 0; i < articleDOMS.length; i++) {
@@ -159,7 +146,7 @@ const riponScraper = async (proxy = false) => {
       articles.push(objectToPush);
     }
   }
-
+  stopSpinner();
   return articles;
 };
 

--- a/scrapers/riponScraper.js
+++ b/scrapers/riponScraper.js
@@ -1,6 +1,7 @@
 // Imports
 const cheerio = require("cheerio");
 const { fetchWithProxy } = require("../proxyFetch");
+const moment = require("moment");
 
 // @ desc Scrapes Ripon Leader for article URLS.
 // @ returns array of article URLS to scrape.
@@ -127,6 +128,7 @@ const riponScraper = async (proxy = false) => {
 
     // Getting more Data with one-liners.
     const date = $("time.tnt-date").text().trim();
+    const datetime = moment(date, "MMM D, YYYY").toDate();
     const author = $("a.tnt-user-name:eq(1)").text().trim();
     const source = urls[i];
     const publisher = "Ripon Journal";
@@ -144,6 +146,7 @@ const riponScraper = async (proxy = false) => {
     objectToPush["subHeading"] = subHeading;
     objectToPush["author"] = author;
     objectToPush["date"] = date;
+    objectToPush["datetime"] = datetime;
     objectToPush["thumbnail"] = thumbnail.src
       ? thumbnail
       : image.src

--- a/scrapers/riponScraper.js
+++ b/scrapers/riponScraper.js
@@ -128,10 +128,10 @@ const riponScraper = async (proxy = false) => {
 
     // Getting more Data with one-liners.
     const date = $("time.tnt-date").text().trim();
-    const datetime = moment(date, "MMM D, YYYY").toDate();
+    const datetime = moment($("time.tnt-date").attr("datetime")).toDate();
     const author = $("a.tnt-user-name:eq(1)").text().trim();
     const source = urls[i];
-    const publisher = "Ripon Journal";
+    const publisher = "The Ripon Press";
     const heading = $("h1.headline").text().trim();
     const subHeading = $("h2.subhead").text().trim() || null;
     const thumbnail = thumbnails[i];

--- a/scrapers/riverbankScraper.js
+++ b/scrapers/riverbankScraper.js
@@ -176,7 +176,7 @@ const riverbankNewsScraper = async (proxy = false) => {
     const subHeading = $("div.anvil-article__subtitle").text().trim() || null;
     const author = jsonData.page_meta.author || paragraphs[0];
     const date = jsonData.page_meta.page_created_at_pretty;
-    const datetime = moment(date, "MMMM D, YYYY").toDate();
+    const datetime = moment(jsonData.page_created_at).toDate();
     const image = { src: $image.attr("src"), alt: $image.attr("alt") };
 
     // Saving data to an object I will push to the array of objects.

--- a/scrapers/riverbankScraper.js
+++ b/scrapers/riverbankScraper.js
@@ -1,5 +1,6 @@
 const cheerio = require("cheerio");
 const { fetchWithProxy } = require("../proxyFetch");
+const moment = require("moment");
 
 // GLOBAL VARIABLE //
 const subcategoriesObj = {};
@@ -175,6 +176,7 @@ const riverbankNewsScraper = async (proxy = false) => {
     const subHeading = $("div.anvil-article__subtitle").text().trim() || null;
     const author = jsonData.page_meta.author || paragraphs[0];
     const date = jsonData.page_meta.page_created_at_pretty;
+    const datetime = moment(date, "MMMM D, YYYY").toDate();
     const image = { src: $image.attr("src"), alt: $image.attr("alt") };
 
     // Saving data to an object I will push to the array of objects.
@@ -186,6 +188,7 @@ const riverbankNewsScraper = async (proxy = false) => {
     objectToPush["subcategory"] = subcategory;
     objectToPush["author"] = author;
     objectToPush["date"] = date;
+    objectToPush["datetime"] = datetime;
     objectToPush["img"] = image;
     objectToPush["thumbnail"] = thumbnails[i];
     objectToPush["paragraphs"] = paragraphs;

--- a/scrapers/riverbankScraper.js
+++ b/scrapers/riverbankScraper.js
@@ -40,7 +40,7 @@ const getRiverbankURLS = async (proxy = false) => {
   let highSchoolPromise;
   // Getting Category DOMS
 
-  process.stdout.write("Fetching Category DOMS ");
+  console.log("Fetching Category DOMS ");
   startSpinner();
   crimePromise = fetch(crimeURL).then((res) => res.text());
   govPromise = fetch(govURL).then((res) => res.text());

--- a/scrapers/riverbankScraper.js
+++ b/scrapers/riverbankScraper.js
@@ -1,6 +1,7 @@
 const cheerio = require("cheerio");
 const { fetchWithProxy } = require("../proxyFetch");
 const moment = require("moment");
+const { startSpinner, stopSpinner } = require("../delays");
 
 // GLOBAL VARIABLE //
 const subcategoriesObj = {};
@@ -38,23 +39,15 @@ const getRiverbankURLS = async (proxy = false) => {
   let localSportsPromise;
   let highSchoolPromise;
   // Getting Category DOMS
-  if (!proxy) {
-    console.log("Fetching Category DOMS");
-    crimePromise = fetch(crimeURL).then((res) => res.text());
-    govPromise = fetch(govURL).then((res) => res.text());
-    edPromise = fetch(edURL).then((res) => res.text());
-    localNewsPromise = fetch(localNewsURL).then((res) => res.text());
-    localSportsPromise = fetch(localSportsURL).then((res) => res.text());
-    highSchoolPromise = fetch(highSchoolURL).then((res) => res.text());
-  } else {
-    console.log("Fetching Category DOMS with Proxy");
-    crimePromise = fetchWithProxy(crimeURL);
-    govPromise = fetchWithProxy(govURL);
-    edPromise = fetchWithProxy(edURL);
-    localNewsPromise = fetchWithProxy(localNewsURL);
-    localSportsPromise = fetchWithProxy(localSportsURL);
-    highSchoolPromise = fetchWithProxy(highSchoolURL);
-  }
+
+  process.stdout.write("Fetching Category DOMS ");
+  startSpinner();
+  crimePromise = fetch(crimeURL).then((res) => res.text());
+  govPromise = fetch(govURL).then((res) => res.text());
+  edPromise = fetch(edURL).then((res) => res.text());
+  localNewsPromise = fetch(localNewsURL).then((res) => res.text());
+  localSportsPromise = fetch(localSportsURL).then((res) => res.text());
+  highSchoolPromise = fetch(highSchoolURL).then((res) => res.text());
   const [crimeDOM, govDOM, edDOM, localNewsDOM, localSportsDOM, highSchoolDOM] =
     await Promise.all([
       crimePromise,
@@ -64,6 +57,7 @@ const getRiverbankURLS = async (proxy = false) => {
       localSportsPromise,
       highSchoolPromise,
     ]);
+  stopSpinner();
   console.log("Got all Category DOMS");
 
   // Creating cheerio objects out of DOM strings.
@@ -110,32 +104,22 @@ const riverbankNewsScraper = async (proxy = false) => {
   // Getting article URLS
   let urls;
   let thumbnails;
-  if (!proxy) {
-    const [resURLS, resThumbnails] = await getRiverbankURLS();
-    urls = resURLS;
-    thumbnails = resThumbnails;
-  } else {
-    const [resURLS, resThumbnails] = await getRiverbankURLS(true);
-    urls = resURLS;
-    thumbnails = resThumbnails;
-  }
+  const [resURLS, resThumbnails] = await getRiverbankURLS();
+  urls = resURLS;
+  thumbnails = resThumbnails;
   console.log("Got all article URLS");
 
   // Getting article DOMS
   let URLpromises;
-  if (!proxy) {
-    console.log("Getting article DOMS");
-    URLpromises = urls.map((url) => {
-      return fetch(url).then((res) => res.text());
-    });
-  } else {
-    console.log("Getting article DOMS with Proxy");
-    URLpromises = urls.map((url) => {
-      return fetchWithProxy(url);
-    });
-  }
+  console.log("Getting article DOMS ");
+  startSpinner();
+  URLpromises = urls.map((url) => {
+    return fetch(url).then((res) => res.text());
+  });
   const articleDOMS = await Promise.all(URLpromises);
-  console.log("Got all article DOMS, Scraping Data...");
+  stopSpinner();
+  console.log("Got all article DOMS, Scraping Data... ");
+  startSpinner();
 
   // Iterating over DOM strings, turning them into objects, and pushing them to articles array.
   for (let i = 0; i < articleDOMS.length; i++) {
@@ -195,6 +179,7 @@ const riverbankNewsScraper = async (proxy = false) => {
 
     articles.push(objectToPush);
   }
+  stopSpinner();
   return articles;
 };
 

--- a/scrapers/tracyScraper.js
+++ b/scrapers/tracyScraper.js
@@ -47,6 +47,7 @@ const getTracyURLS = async (proxy = false) => {
 
   // Getting Category DOMS.
   console.log("Fetching Category DOMS ");
+  startSpinner();
   crimePromise = fetchDelay(crimeNewsURL);
   govPromise = fetchDelay(govNewsURL);
   edPromise = fetchDelay(educationNewsURL);
@@ -68,6 +69,7 @@ const getTracyURLS = async (proxy = false) => {
     highSchoolSportsPromise,
     localSportsPromise,
   ]);
+  stopSpinner();
   console.log("Got all Category DOMS");
 
   // Creating cheerio object out of DOM strings.
@@ -121,7 +123,7 @@ const tracyPressScraper = async (proxy = false) => {
 
   // Getting Article DOMS
   let URLpromises;
-  console.log("Getting article DOMS ");
+  console.log("Fetching article DOMS ");
   startSpinner();
   URLpromises = urls.map((url) => {
     return fetch(url)

--- a/scrapers/tracyScraper.js
+++ b/scrapers/tracyScraper.js
@@ -1,5 +1,6 @@
 const cheerio = require("cheerio");
 const { fetchWithProxy } = require("../proxyFetch");
+const moment = require("moment");
 
 // GLOBAL VARS FOR CATEGORIZING ARTICLES //
 subcategoriesObj = {};
@@ -165,6 +166,18 @@ const tracyPressScraper = async (proxy = false) => {
       .find("time")
       .text()
       .trim();
+    let datetime;
+    try {
+      datetime = $("div.meta")
+        .find("span")
+        .find("ul")
+        .find("li.visible-print")
+        .find("time")
+        .attr("datetime");
+      datetime = moment(datetime).toDate();
+    } catch {
+      datetime = null;
+    }
 
     // Getting Image.
     const src = $("div.image").find("div").children().eq(2).attr("content");
@@ -197,6 +210,7 @@ const tracyPressScraper = async (proxy = false) => {
     objectToPush["subcategory"] = subcategory;
     objectToPush["author"] = author;
     objectToPush["date"] = date;
+    objectToPush["datetime"] = datetime;
     objectToPush["img"] = image.src ? image : null;
     objectToPush["thumbnail"] = image.src ? image : null;
     objectToPush["paragraphs"] = paragraphs;

--- a/scrapers/tracyScraper.js
+++ b/scrapers/tracyScraper.js
@@ -215,6 +215,7 @@ const tracyPressScraper = async (proxy = false) => {
     objectToPush["thumbnail"] = image.src ? image : null;
     objectToPush["paragraphs"] = paragraphs;
 
+    console.log(objectToPush);
     // Pushing object to articles array.
     if (objectToPush.paragraphs.length != 0) {
       articles.push(objectToPush);

--- a/scrapers/tracyScraper.js
+++ b/scrapers/tracyScraper.js
@@ -49,12 +49,12 @@ const getTracyURLS = async (proxy = false) => {
   // Getting Category DOMS.
   console.log("Fetching Category DOMS ");
   startSpinner();
-  crimePromise = fetchWithProxyTracy(crimeNewsURL);
-  govPromise = fetchWithProxyTracy(govNewsURL);
-  edPromise = fetchWithProxyTracy(educationNewsURL);
-  localNewsPromise = fetchWithProxyTracy(localNewsURL);
-  localSportsPromise = fetchWithProxyTracy(localSportsURL);
-  highSchoolSportsPromise = fetchWithProxyTracy(highSchoolSportsURL);
+  crimePromise = fetchDelay(crimeNewsURL);
+  govPromise = fetchDelay(govNewsURL);
+  edPromise = fetchDelay(educationNewsURL);
+  localNewsPromise = fetchDelay(localNewsURL);
+  localSportsPromise = fetchDelay(localSportsURL);
+  highSchoolSportsPromise = fetchDelay(highSchoolSportsURL);
   const [
     crimeDOM,
     govDOM,

--- a/scrapers/tracyScraper.js
+++ b/scrapers/tracyScraper.js
@@ -126,7 +126,7 @@ const tracyPressScraper = async (proxy = false) => {
   console.log("Fetching article DOMS ");
   startSpinner();
   URLpromises = urls.map((url) => {
-    return fetch(url)
+    return fetchDelay(url)
       .then((res) => res.text())
       .catch((e) => `${e.message} Could not get ${url}`);
   });

--- a/scrapers/tracyScraper.js
+++ b/scrapers/tracyScraper.js
@@ -1,5 +1,5 @@
 const cheerio = require("cheerio");
-const { fetchWithProxy } = require("../proxyFetch");
+const { fetchWithProxy, fetchWithProxyTracy } = require("../proxyFetch");
 const moment = require("moment");
 
 const {
@@ -7,6 +7,7 @@ const {
   stopSpinner,
   smallFetchDelay,
   fetchDelay,
+  fetchDelayTracy,
 } = require("../delays");
 
 // GLOBAL VARS FOR CATEGORIZING ARTICLES //
@@ -48,12 +49,12 @@ const getTracyURLS = async (proxy = false) => {
   // Getting Category DOMS.
   console.log("Fetching Category DOMS ");
   startSpinner();
-  crimePromise = fetchDelay(crimeNewsURL);
-  govPromise = fetchDelay(govNewsURL);
-  edPromise = fetchDelay(educationNewsURL);
-  localNewsPromise = fetchDelay(localNewsURL);
-  localSportsPromise = fetchDelay(localSportsURL);
-  highSchoolSportsPromise = fetchDelay(highSchoolSportsURL);
+  crimePromise = fetchWithProxyTracy(crimeNewsURL);
+  govPromise = fetchWithProxyTracy(govNewsURL);
+  edPromise = fetchWithProxyTracy(educationNewsURL);
+  localNewsPromise = fetchWithProxyTracy(localNewsURL);
+  localSportsPromise = fetchWithProxyTracy(localSportsURL);
+  highSchoolSportsPromise = fetchWithProxyTracy(highSchoolSportsURL);
   const [
     crimeDOM,
     govDOM,
@@ -107,7 +108,9 @@ const getTracyURLS = async (proxy = false) => {
     ...highSchoolSportsArticleURLS,
     ...localSportsArticleURLS,
   ];
-  return articleURLS;
+  let uniqueURLS = new Set(articleURLS);
+  let uniqueURLSArray = Array.from(uniqueURLS);
+  return uniqueURLSArray;
 };
 
 // @ desc Scrapes Oakdale Leader
@@ -126,9 +129,7 @@ const tracyPressScraper = async (proxy = false) => {
   console.log("Fetching article DOMS ");
   startSpinner();
   URLpromises = urls.map((url) => {
-    return fetchDelay(url)
-      .then((res) => res.text())
-      .catch((e) => `${e.message} Could not get ${url}`);
+    return fetchWithProxyTracy(url);
   });
   const articleDOMS = await Promise.all(URLpromises);
   stopSpinner();
@@ -175,7 +176,8 @@ const tracyPressScraper = async (proxy = false) => {
     const image = { src, alt };
 
     // Getting paragraphs.
-    const paragraphs = [];
+    let paragraphs = [];
+
     $("div.asset-content")
       .find("p")
       .each((i, element) => {
@@ -209,6 +211,7 @@ const tracyPressScraper = async (proxy = false) => {
     if (objectToPush.paragraphs.length != 0) {
       articles.push(objectToPush);
     }
+    articles.push(objectToPush);
   }
   stopSpinner();
   return articles;

--- a/scrapers/turlockScraper.js
+++ b/scrapers/turlockScraper.js
@@ -1,5 +1,6 @@
 const cheerio = require("cheerio");
 const { fetchWithProxy } = require("../proxyFetch");
+const moment = require("moment");
 
 // GLOBAL VARIABLE///
 const subcategoriesObj = {};
@@ -175,6 +176,7 @@ const turlockJournalScraper = async (proxy = false) => {
     const subHeading = $("div.anvil-article__subtitle").text().trim() || null;
     const author = jsonData.page_meta.author || paragraphs[0];
     const date = jsonData.page_meta.page_created_at_pretty;
+    const datetime = moment(date, "MMMM D, YYYY").toDate();
     const image = { src: $image.attr("src"), alt: $image.attr("alt") };
     const [category, subcategory] = getCategories(source);
 
@@ -187,6 +189,7 @@ const turlockJournalScraper = async (proxy = false) => {
     objectToPush["subcategory"] = subcategory;
     objectToPush["author"] = author;
     objectToPush["date"] = date;
+    objectToPush["datetime"] = datetime;
     objectToPush["img"] = image;
     objectToPush["thumbnail"] = thumbnails[i];
     objectToPush["paragraphs"] = paragraphs;

--- a/scrapers/turlockScraper.js
+++ b/scrapers/turlockScraper.js
@@ -176,7 +176,7 @@ const turlockJournalScraper = async (proxy = false) => {
     const subHeading = $("div.anvil-article__subtitle").text().trim() || null;
     const author = jsonData.page_meta.author || paragraphs[0];
     const date = jsonData.page_meta.page_created_at_pretty;
-    const datetime = moment(date, "MMMM D, YYYY").toDate();
+    const datetime = moment(jsonData.page_created_at).toDate();
     const image = { src: $image.attr("src"), alt: $image.attr("alt") };
     const [category, subcategory] = getCategories(source);
 

--- a/scrapers/turlockScraper.js
+++ b/scrapers/turlockScraper.js
@@ -40,7 +40,7 @@ const getTurlockURLS = async (proxy = false) => {
   let highSchoolPromise;
 
   // Getting Category DOMS
-  process.stdout.write("Fetching Category DOMS ");
+  console.log("Fetching Category DOMS ");
   startSpinner();
   crimePromise = fetch(crimeURLS).then((res) => res.text());
   govPromise = fetch(govURLS).then((res) => res.text());

--- a/scrapers/turlockScraper.js
+++ b/scrapers/turlockScraper.js
@@ -1,6 +1,7 @@
 const cheerio = require("cheerio");
 const { fetchWithProxy } = require("../proxyFetch");
 const moment = require("moment");
+const { startSpinner, stopSpinner } = require("../delays");
 
 // GLOBAL VARIABLE///
 const subcategoriesObj = {};
@@ -39,23 +40,14 @@ const getTurlockURLS = async (proxy = false) => {
   let highSchoolPromise;
 
   // Getting Category DOMS
-  if (!proxy) {
-    console.log("Fetching Category DOMS");
-    crimePromise = fetch(crimeURLS).then((res) => res.text());
-    govPromise = fetch(govURLS).then((res) => res.text());
-    edPromise = fetch(edURLS).then((res) => res.text());
-    localNewsPromise = fetch(localNewsURLS).then((res) => res.text());
-    localSportsPromise = fetch(localSportsURLS).then((res) => res.text());
-    highSchoolPromise = fetch(highSchoolURLS).then((res) => res.text());
-  } else {
-    console.log("Fetching Category DOMS with Proxy");
-    crimePromise = fetchWithProxy(crimeURLS);
-    govPromise = fetchWithProxy(govURLS);
-    edPromise = fetchWithProxy(edURLS);
-    localNewsPromise = fetchWithProxy(localNewsURLS);
-    localSportsPromise = fetchWithProxy(localSportsURLS);
-    highSchoolPromise = fetchWithProxy(highSchoolURLS);
-  }
+  process.stdout.write("Fetching Category DOMS ");
+  startSpinner();
+  crimePromise = fetch(crimeURLS).then((res) => res.text());
+  govPromise = fetch(govURLS).then((res) => res.text());
+  edPromise = fetch(edURLS).then((res) => res.text());
+  localNewsPromise = fetch(localNewsURLS).then((res) => res.text());
+  localSportsPromise = fetch(localSportsURLS).then((res) => res.text());
+  highSchoolPromise = fetch(highSchoolURLS).then((res) => res.text());
   const [crimeDOM, govDOM, edDOM, localNewsDOM, localSportsDOM, highSchoolDOM] =
     await Promise.all([
       crimePromise,
@@ -65,6 +57,7 @@ const getTurlockURLS = async (proxy = false) => {
       localSportsPromise,
       highSchoolPromise,
     ]);
+  stopSpinner();
   console.log("Got all Category DOMS");
 
   // Creating cheerio objects out of DOM strings.
@@ -113,30 +106,22 @@ const turlockJournalScraper = async (proxy = false) => {
   // Getting article URLS.
   let urls;
   let thumbnails;
-  if (!proxy) {
-    const [resURLS, resThumbnails] = await getTurlockURLS();
-    urls = resURLS;
-    thumbnails = resThumbnails;
-  } else {
-    const [resURLS, resThumbnails] = await getTurlockURLS(true);
-    urls = resURLS;
-    thumbnails = resThumbnails;
-  }
+  const [resURLS, resThumbnails] = await getTurlockURLS();
+  urls = resURLS;
+  thumbnails = resThumbnails;
   console.log("Got all article URLS");
 
   // Getting article DOMS
   let URLpromises;
-  if (!proxy) {
-    URLpromises = urls.map((url) => {
-      return fetch(url).then((res) => res.text());
-    });
-  } else {
-    URLpromises = urls.map((url) => {
-      return fetchWithProxy(url);
-    });
-  }
+  console.log("Getting article DOMS ");
+  startSpinner();
+  URLpromises = urls.map((url) => {
+    return fetch(url).then((res) => res.text());
+  });
   const articleDOMS = await Promise.all(URLpromises);
-  console.log("Got all article DOMS, Scraping Data...");
+  stopSpinner();
+  console.log("Got all article DOMS, Scraping Data... ");
+  startSpinner();
 
   // Iterating over each DOM in article DOM, and creating article object to push to articles array.
   for (let i = 0; i < articleDOMS.length; i++) {
@@ -196,6 +181,7 @@ const turlockJournalScraper = async (proxy = false) => {
 
     articles.push(objectToPush);
   }
+  stopSpinner();
   return articles;
 };
 


### PR DESCRIPTION
This scraper is ready for the backend to use as long as they are okay with filtering the articles by datetime property using SQL.

The Scraper runs in an AVG of 1:35 seconds.
It scraped 1023 articles.
Used proxies and fetch delays to get over 2 of the rate limiting sites.

If you plan on using it, get the proxy env variables from the Notion app!